### PR TITLE
Sync Google Play store metadata automatically

### DIFF
--- a/.github/workflows/google-play-metadata.yml
+++ b/.github/workflows/google-play-metadata.yml
@@ -1,0 +1,33 @@
+name: Sync Google Play listing
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "fastlane/metadata/android/**"
+      - "fastlane/Fastfile"
+      - "fastlane/Appfile"
+      - ".github/workflows/google-play-metadata.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: google-play-metadata
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - run: gem install fastlane -v 2.237.0 --no-document
+      - name: Configure Google Play credentials
+        run: |
+          mkdir -p ~/.config
+          printf '%s' '${{ secrets.GOOGLE_PLAY_JSON_KEY }}' > ~/.config/googlePlay.json
+      - run: fastlane android metadata track:production

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,4 +83,17 @@ platform :android do
     build_release
   end
 
+  desc "Upload the complete Google Play store listing without a binary release"
+  lane :metadata do |options|
+    upload_to_play_store(
+      track: options[:track] || "production",
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_changelogs: true,
+      skip_upload_metadata: false,
+      skip_upload_images: false,
+      skip_upload_screenshots: false
+    )
+  end
+
 end

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,25 +1,27 @@
-BeatBridge automatically resumes music playback the moment your chosen Bluetooth device connects — your car speakers, headphones, or any paired device.
+Make Bluetooth music playback feel automatic.
+
+BeatBridge resumes music when the Bluetooth device you choose connects. Use it with your car, headphones, speakers, or any paired Bluetooth device, then carry on listening in the media app you already use.
 
 HOW IT WORKS
 
-Select one paired Bluetooth device from the list. BeatBridge starts a lightweight foreground service that listens for that device to connect. When it does, BeatBridge sends a standard media play event to Android, resuming whatever you were last listening to in Spotify, YouTube Music, Pocket Casts, or any other media app.
+Choose a paired Bluetooth device and enable monitoring. When that device connects, BeatBridge sends Android's standard media play command to the active media session. Compatible music, podcast, and audiobook apps can then resume playback.
 
-FEATURES
+KEY FEATURES
 
-• One-tap setup — pick your device and you're done
-• Works with any media player that responds to Android media key events
-• Persistent — keeps watching even after the app is closed
-• No polling — wakes only on Bluetooth connection events, so battery impact is minimal
-• Fully offline — no internet access, no accounts, no tracking
+• Auto-play music when a selected Bluetooth device connects
+• Works with Android media controls used by many music, podcast, and audiobook apps
+• Choose between automatic playback or an “Ask on connect” notification
+• Open your media app or audio settings directly from the connection notification
+• Create a per-device equalizer profile
+• Keep monitoring active in the background with a lightweight foreground service
+• Designed for efficient Bluetooth connection events, without constant polling
+
+PRIVATE BY DESIGN
+
+BeatBridge works offline. It has no accounts, ads, analytics, or network access. Your selected devices and preferences stay on your device.
 
 PERMISSIONS
 
-• Bluetooth — to read your list of paired devices and detect when one connects
-• Foreground Service — to keep the monitor running in the background
-• Notifications — to display the persistent "Watching for…" status notification (Android 13+)
+Bluetooth access lets BeatBridge list paired devices and detect connections. A foreground service keeps monitoring active in the background, and notifications show its connection status and optional actions.
 
-No location access. No storage access. No network access.
-
-OPEN SOURCE
-
-BeatBridge is free and open-source software licensed under the GNU General Public License v3. Source code is available on GitHub.
+BeatBridge is open-source software licensed under GPLv3.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Auto-play music when your Bluetooth device connects.
+Auto-play music when your Bluetooth car, headphones, or speakers connect.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-BeatBridge
+BeatBridge: Bluetooth Music


### PR DESCRIPTION
Adds ASO copy and an automatic Fastlane metadata sync. The workflow runs when Play metadata or Fastlane configuration changes.