### PR TITLE
Harden release pipeline and Bluetooth monitor state

### DIFF
--- a/.github/scripts/run-e2e.sh
+++ b/.github/scripts/run-e2e.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./gradlew assembleDebug assembleDebugAndroidTest --stacktrace
+
+DEVICE_ABI="$(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
+APP_APK="app/build/outputs/apk/debug/app-${DEVICE_ABI}-debug.apk"
+TEST_APK="app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+
+test -s "$APP_APK"
+test -s "$TEST_APK"
+
+adb install -t -r "$APP_APK"
+adb install -t -r "$TEST_APK"
+adb shell pm grant com.beatbridge android.permission.BLUETOOTH_CONNECT
+adb shell pm grant com.beatbridge android.permission.POST_NOTIFICATIONS
+
+mkdir -p artifacts/e2e artifacts/screenshots
+adb shell am instrument -w \
+  com.beatbridge.test/androidx.test.runner.AndroidJUnitRunner \
+  | tee artifacts/e2e/instrumentation.log
+
+adb pull /sdcard/Android/data/com.beatbridge/files/screenshots/. artifacts/screenshots/
+
+for screenshot in \
+  01_empty_state.png \
+  02_devices_found.png \
+  03_device_selected.png \
+  04_full_list.png; do
+  test -s "artifacts/screenshots/$screenshot"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
           git push origin ${{ steps.version.outputs.tag }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: BeatBridge ${{ steps.version.outputs.tag }}
@@ -287,7 +287,7 @@ jobs:
 
       - name: VirusTotal Scan
         id: vt
-        uses: crazy-max/ghaction-virustotal@v4
+        uses: crazy-max/ghaction-virustotal@v5
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-test:
     name: Build & Unit Test
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[release-bump]')
     runs-on: ubuntu-latest
 
     steps:
@@ -48,6 +49,7 @@ jobs:
 
   instrumented-e2e:
     name: E2E & Screenshots
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[release-bump]')
     runs-on: ubuntu-latest
 
     steps:
@@ -151,6 +153,7 @@ jobs:
             grep -v "^Merge " | \
             grep -v "^Bump " | \
             grep -v "\[skip-ci\]" | \
+            grep -v "\[release-bump\]" | \
             grep -v "^ci:" | \
             grep -v "^chore:" | \
             grep -v "^test:" | \
@@ -194,7 +197,7 @@ jobs:
           VERSION=$(grep ^versionName version.properties | cut -d '=' -f2 | tr -d '\r')
           DATE=$(date +%Y-%m-%d)
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
-          COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" | grep -v '\[skip-ci\]' || true)
+          COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" | grep -v '\[skip-ci\]' | grep -v '\[release-bump\]' || true)
           if [ -n "$COMMITS" ]; then
             NEW_SECTION="## [${VERSION}] - ${DATE}\n\n### Changed\n${COMMITS}\n"
             awk -v new="$NEW_SECTION" '/^## \[/{if(!done){print new; done=1}} {print}' CHANGELOG.md > CHANGELOG.tmp
@@ -240,7 +243,7 @@ jobs:
           git config --local user.name "GitHub Action"
           VERSION=$(grep ^versionName version.properties | cut -d '=' -f2 | tr -d '\r')
           git add version.properties CHANGELOG.md app/src/main/assets/changelogs/ fastlane/metadata/android/en-US/images/phoneScreenshots/
-          git commit -m "Bump to $VERSION [skip-ci]"
+          git commit -m "Bump to $VERSION [release-bump]"
           git tag ${{ steps.version.outputs.tag }}
           git push origin HEAD:master
           git push origin ${{ steps.version.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew assembleDebug --stacktrace
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug-apk-${{ github.sha }}
           path: app/build/outputs/apk/debug/app-debug.apk
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-results-${{ github.sha }}
           path: app/build/reports/tests/
@@ -52,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -80,29 +80,11 @@ jobs:
           profile: pixel_2
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -no-audio -no-boot-anim -camera-back none
-          script: |
-            set -o pipefail
-            ./gradlew assembleDebug assembleDebugAndroidTest --stacktrace
-            DEVICE_ABI=$(adb shell getprop ro.product.cpu.abi)
-            APP_APK="app/build/outputs/apk/debug/app-${DEVICE_ABI}-debug.apk"
-            TEST_APK="app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-            adb install -t -r "$APP_APK"
-            adb install -t -r "$TEST_APK"
-            adb shell pm grant com.beatbridge android.permission.BLUETOOTH_CONNECT
-            adb shell pm grant com.beatbridge android.permission.POST_NOTIFICATIONS
-            mkdir -p artifacts/e2e artifacts/screenshots
-            adb shell am instrument -w \
-              com.beatbridge.test/androidx.test.runner.AndroidJUnitRunner \
-              | tee artifacts/e2e/instrumentation.log
-            adb pull /sdcard/Android/data/com.beatbridge/files/screenshots/. artifacts/screenshots/
-            test -s artifacts/screenshots/01_empty_state.png
-            test -s artifacts/screenshots/02_devices_found.png
-            test -s artifacts/screenshots/03_device_selected.png
-            test -s artifacts/screenshots/04_full_list.png
+          script: bash .github/scripts/run-e2e.sh
 
       - name: Upload E2E test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-test-results-${{ github.sha }}
           path: artifacts/e2e/
@@ -111,7 +93,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-screenshots-${{ github.sha }}
           path: artifacts/screenshots/
@@ -129,11 +111,13 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
+      - name: Checkout source with release history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -195,7 +179,6 @@ jobs:
             echo "• Bug fixes and improvements" > "$ASSET_DIR/$TIMESTAMP.txt"
           fi
 
-          # Deduplicate: skip if first line already exists in another file
           FIRST=$(head -1 "$ASSET_DIR/$TIMESTAMP.txt" | sed 's/[.[\*^$()+?{|]/\\&/g')
           DUP=$(grep -rl "^${FIRST}$" "$ASSET_DIR/" 2>/dev/null | grep -v "$TIMESTAMP.txt" | head -1)
           if [ -n "$DUP" ]; then
@@ -219,21 +202,10 @@ jobs:
           fi
 
       - name: Download verified E2E screenshots
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: e2e-screenshots-${{ github.sha }}
           path: fastlane/metadata/android/en-US/images/phoneScreenshots
-
-      - name: Commit and push new version
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          VERSION=$(grep ^versionName version.properties | cut -d '=' -f2 | tr -d '\r')
-          git add version.properties CHANGELOG.md app/src/main/assets/changelogs/ fastlane/metadata/android/en-US/images/phoneScreenshots/
-          git commit -m "Bump to $VERSION [skip-ci]"
-          git tag ${{ steps.version.outputs.tag }}
-          git push origin master
-          git push origin ${{ steps.version.outputs.tag }}
 
       - name: Build release APKs
         run: ./gradlew assembleRelease --stacktrace
@@ -246,16 +218,32 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           OUTDIR="app/build/outputs/apk/release"
+          APK_COUNT=0
           for APK in "$OUTDIR"/app-*-release.apk; do
+            test -f "$APK"
             ABI=$(basename "$APK" | sed 's/app-\(.*\)-release\.apk/\1/')
             cp "$APK" "$OUTDIR/BeatBridge-${TAG}-${ABI}.apk"
+            APK_COUNT=$((APK_COUNT + 1))
           done
+          test "$APK_COUNT" -eq 4
 
       - name: Upload release APKs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-apks
           path: app/build/outputs/apk/release/BeatBridge-*.apk
+          if-no-files-found: error
+
+      - name: Commit and tag verified release inputs
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          VERSION=$(grep ^versionName version.properties | cut -d '=' -f2 | tr -d '\r')
+          git add version.properties CHANGELOG.md app/src/main/assets/changelogs/ fastlane/metadata/android/en-US/images/phoneScreenshots/
+          git commit -m "Bump to $VERSION [skip-ci]"
+          git tag ${{ steps.version.outputs.tag }}
+          git push origin HEAD:master
+          git push origin ${{ steps.version.outputs.tag }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -286,10 +274,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download release APKs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-apks
           path: release-apks

--- a/.github/workflows/google-play-metadata.yml
+++ b/.github/workflows/google-play-metadata.yml
@@ -21,13 +21,17 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
       - run: gem install fastlane -v 2.237.0 --no-document
       - name: Configure Google Play credentials
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
         run: |
-          mkdir -p ~/.config
-          printf '%s' '${{ secrets.GOOGLE_PLAY_JSON_KEY }}' > ~/.config/googlePlay.json
+          install -d -m 700 "$HOME/.config"
+          printf '%s' "$GOOGLE_PLAY_JSON_KEY" > "$HOME/.config/googlePlay.json"
+          chmod 600 "$HOME/.config/googlePlay.json"
+          echo "GOOGLE_PLAY_JSON_KEY_PATH=$HOME/.config/googlePlay.json" >> "$GITHUB_ENV"
       - run: fastlane android metadata track:production

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,10 +24,7 @@ android {
         testInstrumentationRunnerArguments["grantAll"] = "true"
     }
 
-    val keyPropsFile = sequenceOf(
-        rootProject.file("key.properties"),
-        File(System.getProperty("user.home"), "flexify/android/key.properties")
-    ).firstOrNull { it.exists() }
+    val keyPropsFile = rootProject.file("key.properties").takeIf { it.exists() }
     val keyProps = Properties().also { props ->
         if (keyPropsFile != null) keyPropsFile.inputStream().use { props.load(it) }
     }

--- a/app/src/main/java/com/beatbridge/BluetoothMonitorService.kt
+++ b/app/src/main/java/com/beatbridge/BluetoothMonitorService.kt
@@ -24,8 +24,10 @@ class BluetoothMonitorService : Service() {
 
     private val handler = Handler(Looper.getMainLooper())
     private var equalizer: Equalizer? = null
+    private var equalizerDeviceAddress: String? = null
 
     private val bluetoothReceiver = object : BroadcastReceiver() {
+        @SuppressLint("MissingPermission")
         override fun onReceive(context: Context, intent: Intent) {
             val device: BluetoothDevice? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
@@ -36,7 +38,11 @@ class BluetoothMonitorService : Service() {
 
             when (intent.action) {
                 BluetoothDevice.ACTION_ACL_CONNECTED -> device?.let { handleDeviceConnected(it) }
-                BluetoothDevice.ACTION_ACL_DISCONNECTED -> releaseEqualizer()
+                BluetoothDevice.ACTION_ACL_DISCONNECTED -> {
+                    if (device == null || device.address == equalizerDeviceAddress) {
+                        releaseEqualizer()
+                    }
+                }
             }
         }
     }
@@ -89,25 +95,28 @@ class BluetoothMonitorService : Service() {
     }
 
     private fun applyEqualizer(prefs: SharedPreferences, address: String) {
+        releaseEqualizer()
+
         val raw = prefs.getString("${MainActivity.PREF_DEVICE_EQ_PREFIX}$address", null) ?: return
         val levels = raw.split(",").mapNotNull { it.toShortOrNull() }
         if (levels.isEmpty()) return
         try {
-            equalizer?.release()
             val eq = Equalizer(0, 0)
             eq.enabled = true
             for (i in 0 until minOf(levels.size, eq.numberOfBands.toInt())) {
                 eq.setBandLevel(i.toShort(), levels[i])
             }
             equalizer = eq
+            equalizerDeviceAddress = address
         } catch (_: Exception) {
-            equalizer = null
+            releaseEqualizer()
         }
     }
 
     private fun releaseEqualizer() {
         equalizer?.release()
         equalizer = null
+        equalizerDeviceAddress = null
     }
 
     @SuppressLint("MissingPermission")

--- a/app/src/main/java/com/beatbridge/MainActivity.kt
+++ b/app/src/main/java/com/beatbridge/MainActivity.kt
@@ -79,10 +79,7 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(Intent.ACTION_VIEW, "https://github.com/sponsors/brandonp2412".toUri()))
         }
 
-        val selectedDevices = prefs.getStringSet(PREF_SELECTED_DEVICES, null)
-        if (selectedDevices?.isNotEmpty() == true || prefs.getBoolean(PREF_ANY_DEVICE, false)) {
-            startMonitorService()
-        }
+        syncMonitorService()
     }
 
     private fun loadMusicApps() {
@@ -163,7 +160,7 @@ class MainActivity : AppCompatActivity() {
             prefs.edit { putBoolean(PREF_ANY_DEVICE, isChecked) }
             updateDeviceSectionEnabled(!isChecked)
             updateStatusLabel()
-            startMonitorService()
+            syncMonitorService()
         }
     }
 
@@ -207,7 +204,7 @@ class MainActivity : AppCompatActivity() {
         prefs.edit { putStringSet(PREF_SELECTED_DEVICES, current) }
         deviceAdapter.updateSelections(current)
         updateStatusLabel()
-        startMonitorService()
+        syncMonitorService()
     }
 
     private fun onAppSelected(app: MusicApp) {
@@ -292,8 +289,15 @@ class MainActivity : AppCompatActivity() {
         startActivity(intent)
     }
 
-    fun startMonitorService() {
-        startForegroundService(Intent(this, BluetoothMonitorService::class.java))
+    private fun syncMonitorService() {
+        val selectedAddresses = prefs.getStringSet(PREF_SELECTED_DEVICES, emptySet()) ?: emptySet()
+        val shouldMonitor = prefs.getBoolean(PREF_ANY_DEVICE, false) || selectedAddresses.isNotEmpty()
+        val serviceIntent = Intent(this, BluetoothMonitorService::class.java)
+        if (shouldMonitor) {
+            startForegroundService(serviceIntent)
+        } else {
+            stopService(serviceIntent)
+        }
     }
 
     companion object {

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,1 +1,5 @@
 package_name("com.beatbridge")
+
+if ENV["GOOGLE_PLAY_JSON_KEY_PATH"]
+  json_key_file(ENV["GOOGLE_PLAY_JSON_KEY_PATH"])
+end


### PR DESCRIPTION
Fixes the current emulator CI failure, hardens release sequencing/history, repairs Google Play credential wiring, updates GitHub-hosted actions to current Node 24-compatible majors, removes the stale Flexify signing fallback, stops the monitor service when monitoring is disabled, and ties equalizer lifetime to the device that owns the profile.

Validation target: Build & Unit Test + E2E & Screenshots must pass before merge; release is push-only and will be verified on master after merge.