### PR TITLE
Harden GitHub Actions without breaking releases

### DIFF
--- a/.github/workflows/google-play-metadata.yml
+++ b/.github/workflows/google-play-metadata.yml
@@ -21,8 +21,10 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: "3.3"
       - run: gem install fastlane -v 2.237.0 --no-document

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build & Unit Test
@@ -15,10 +18,12 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -34,7 +39,7 @@ jobs:
         run: ./gradlew assembleDebug --stacktrace
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: debug-apk-${{ github.sha }}
           path: app/build/outputs/apk/debug/app-debug.apk
@@ -42,7 +47,7 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unit-test-results-${{ github.sha }}
           path: app/build/reports/tests/
@@ -55,10 +60,12 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -75,7 +82,7 @@ jobs:
 
       - name: Run instrumented E2E tests and capture screenshots
         timeout-minutes: 15
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 35
           target: google_apis
@@ -87,7 +94,7 @@ jobs:
 
       - name: Upload E2E test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-test-results-${{ github.sha }}
           path: artifacts/e2e/
@@ -96,7 +103,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-screenshots-${{ github.sha }}
           path: artifacts/screenshots/
@@ -115,16 +122,16 @@ jobs:
 
     steps:
       - name: Checkout source with release history
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: "17"
           distribution: "temurin"
-          cache: gradle
 
       - name: Grant Gradle wrapper execute permission
         run: chmod +x gradlew
@@ -198,7 +205,9 @@ jobs:
           fi
 
       - name: Decode keystore
-        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > app/keystore.jks
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
 
       - name: Update changelog
         run: |
@@ -213,55 +222,64 @@ jobs:
           fi
 
       - name: Download verified E2E screenshots
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: e2e-screenshots-${{ github.sha }}
           path: fastlane/metadata/android/en-US/images/phoneScreenshots
 
       - name: Prepare release commit and tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           VERSION=$(grep ^versionName version.properties | cut -d '=' -f2 | tr -d '\r')
           git add version.properties CHANGELOG.md app/src/main/assets/changelogs/ fastlane/metadata/android/en-US/images/phoneScreenshots/
           git commit -m "Bump to $VERSION [release-bump]"
-          git tag ${{ steps.version.outputs.tag }}
+          git tag "$RELEASE_TAG"
 
       - name: Build release APKs from tagged commit
-        run: |
-          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 '${{ steps.version.outputs.tag }}')"
-          test -z "$(git status --porcelain --untracked-files=no)"
-          ./gradlew assembleRelease --stacktrace
         env:
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$RELEASE_TAG")"
+          test -z "$(git status --porcelain --untracked-files=no)"
+          ./gradlew assembleRelease --stacktrace
 
       - name: Rename APKs with version
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
           OUTDIR="app/build/outputs/apk/release"
           APK_COUNT=0
           for APK in "$OUTDIR"/app-*-release.apk; do
             test -f "$APK"
             ABI=$(basename "$APK" | sed 's/app-\(.*\)-release\.apk/\1/')
-            cp "$APK" "$OUTDIR/BeatBridge-${TAG}-${ABI}.apk"
+            cp "$APK" "$OUTDIR/BeatBridge-${RELEASE_TAG}-${ABI}.apk"
             APK_COUNT=$((APK_COUNT + 1))
           done
           test "$APK_COUNT" -eq 4
 
       - name: Upload release APKs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-apks
           path: app/build/outputs/apk/release/BeatBridge-*.apk
           if-no-files-found: error
 
       - name: Publish verified release commit and tag
-        run: git push --atomic origin HEAD:master "refs/tags/${{ steps.version.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh auth setup-git
+          git push --atomic origin HEAD:master "refs/tags/${RELEASE_TAG}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: BeatBridge ${{ steps.version.outputs.tag }}
@@ -289,17 +307,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
-
       - name: Download release APKs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-apks
           path: release-apks
 
       - name: VirusTotal Scan
         id: vt
-        uses: crazy-max/ghaction-virustotal@v5
+        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release/self-commit pilot for the broader Actions hardening rollout.

- Pin every external action to an immutable commit SHA
- Default the workflow token to `contents: read`
- Keep `contents: write` only on release/VirusTotal jobs that actually mutate GitHub state
- Disable persisted checkout credentials
- Re-authenticate Git immediately before the release commit/tag push using the same job-scoped `GITHUB_TOKEN`
- Move tag/secret values out of shell expression interpolation
- Disable Gradle caching in the publishing job
- Preserve the existing generated commit → tag → push → GitHub Release flow

The release job remains guarded to push events on `master`, so this PR exercises build/test/E2E without creating a release.